### PR TITLE
feat(agreements): add resend credentials functionality

### DIFF
--- a/apps/zambia/public/i18n/es.json
+++ b/apps/zambia/public/i18n/es.json
@@ -671,5 +671,9 @@
   "Headquarters": "Sede",
   "Status": "Estado",
   "Created": "Creado en",
-  "Actions": "Acciones"
+  "Actions": "Acciones",
+  "resend_credentials": "Reenviar credenciales",
+  "resend_credentials_confirmation": "¿Estás seguro de que deseas reenviar las credenciales para {{name}} ({{email}})?",
+  "resend_credentials_success": "Las credenciales han sido reenviadas exitosamente",
+  "resend_credentials_failed": "Error al reenviar las credenciales: {{error}}"
 }

--- a/libs/shared/data-access-generic/src/lib/akademy-edge-functions.service.ts
+++ b/libs/shared/data-access-generic/src/lib/akademy-edge-functions.service.ts
@@ -163,4 +163,13 @@ export class AkademyEdgeFunctionsService {
   clearError(): void {
     this.lastError.set(null);
   }
+
+  async resendCredentials(agreementId: string) {
+    return this.invokeFunction<ChangeRoleResponse>('akademy-app/resend-credentials', {
+      method: 'POST',
+      body: {
+        agreement_id: agreementId,
+      },
+    });
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Resend credentials” action in the agreement header with confirmation and clear success/error notifications.

- Enhancements
  - Masked DNI/document number in the personal information section for improved privacy.
  - Expanded Spanish translations to cover the resend credentials flow (labels, confirmation, success, and error messages).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->